### PR TITLE
Ignore Django media and staticfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ cover/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+media/
+staticfiles/
 
 # Flask stuff:
 instance/


### PR DESCRIPTION
## Summary
- ignore Django `media/` and collected `staticfiles/` directories

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6fa21e6ec832892ba368a39d6876f